### PR TITLE
Adjust mobile controls layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,17 @@
     </div>
 
     <div id="mobile-controls">
-        <button id="btn-up" class="control-btn">&#8593;</button>
-        <div class="h-controls">
-            <button id="btn-left" class="control-btn">&#8592;</button>
-            <button id="btn-fire" class="control-btn">&#x1F52B;</button>
-            <button id="btn-right" class="control-btn">&#8594;</button>
+        <div id="left-controls">
+            <button id="btn-up" class="control-btn">&#8593;</button>
+            <div class="h-controls">
+                <button id="btn-left" class="control-btn">&#8592;</button>
+                <button id="btn-right" class="control-btn">&#8594;</button>
+            </div>
+            <button id="btn-down" class="control-btn">&#8595;</button>
         </div>
-        <button id="btn-down" class="control-btn">&#8595;</button>
+        <div id="right-controls">
+            <button id="btn-fire" class="control-btn">&#x1F52B;</button>
+        </div>
     </div>
 
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -75,18 +75,31 @@ canvas {
 #mobile-controls {
     position: absolute;
     bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    width: 100%;
     display: none;
-    flex-direction: column;
+    justify-content: space-between;
     align-items: center;
-    gap: 10px;
+    padding: 0 20px;
+    box-sizing: border-box;
     z-index: 200;
 }
 
-#mobile-controls .h-controls {
+#left-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+#left-controls .h-controls {
     display: flex;
     gap: 10px;
+}
+
+#right-controls {
+    display: flex;
+    align-items: center;
 }
 
 #mobile-controls .control-btn {


### PR DESCRIPTION
## Summary
- Separate directional pad and fire button for better mobile usability
- Style mobile controls for left/right placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b31bc230c8330b271e75eb31fcd3f