### PR TITLE
Add heart drops, shot power-ups, varied enemies and boss stage

### DIFF
--- a/boss.svg
+++ b/boss.svg
@@ -1,0 +1,7 @@
+<svg width="200" height="150" viewBox="0 0 200 150" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="50" width="200" height="50" fill="#8B0000"/>
+  <circle cx="50" cy="75" r="20" fill="#FFD700"/>
+  <circle cx="150" cy="75" r="20" fill="#FFD700"/>
+  <polygon points="100,0 120,50 80,50" fill="#FF6347"/>
+  <polygon points="100,150 120,100 80,100" fill="#FF6347"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div id="game-info">
         <div id="score">スコア: 0</div>
         <div id="health">体力: 100</div>
+        <div id="stage">ステージ: 1</div>
     </div>
 
     <div id="game-over-screen">


### PR DESCRIPTION
## Summary
- Drop healing hearts at 1/20 chance when defeating enemies
- Add blue beam and yellow spread shot power-ups
- Introduce enemy movement patterns and stage system with a large SVG boss after 3 minutes

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b41ad027483308c9a5e54f7ae17b2