### PR TITLE
Reset key states on game restart

### DIFF
--- a/script.js
+++ b/script.js
@@ -231,6 +231,10 @@ function resetGame() {
     powerUps = [];
     powerUpSpawnTimer = 0;
     hearts = [];
+    // 入力状態をリセットしてキー押下が残らないようにする
+    for (const key in keys) {
+        keys[key] = false;
+    }
     score = 0;
     stage = 1;
     stageTimer = 0;


### PR DESCRIPTION
## Summary
- Clear key state when restarting the game to prevent lingering movement or firing

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688b44ea7d788330ad19d7a5c8b10dff