### PR TITLE
Ensure game init after DOM ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -616,14 +616,19 @@ function gameLoop() {
 restartButton.addEventListener('click', resetGame);
 
 // DOMの読み込み後にゲームを開始
-document.addEventListener('DOMContentLoaded', () => {
+function initGame() {
     // キャンバスのサイズを初期化
     canvas.width = canvas.offsetWidth;
     canvas.height = canvas.offsetHeight;
     initStars();
     // 初期化したサイズでゲームをリセット
     resetGame();
-});
+}
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initGame);
+} else {
+    initGame();
+}
 
 // ウィンドウのリサイズ時にキャンバスサイズを調整
 window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- robustly initialize canvas and game even if DOMContentLoaded already fired

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688c8eaa75788330ba82759305be04aa