### PR TITLE
feat: reposition controls and enlarge buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,12 @@
         <canvas id="gameCanvas" width="400" height="600"></canvas>
         <div id="gameControls">
             <div id="touchControls">
-                <button id="leftBtn">←</button>
-                <button id="rightBtn">→</button>
-                <button id="upBtn">↑</button>
-                <button id="downBtn">↓</button>
+                <div id="moveControls">
+                    <button id="leftBtn">←</button>
+                    <button id="rightBtn">→</button>
+                    <button id="upBtn">↑</button>
+                    <button id="downBtn">↓</button>
+                </div>
                 <button id="shootBtn">🔫</button>
             </div>
             <div id="instructions">

--- a/style.css
+++ b/style.css
@@ -56,18 +56,24 @@ body {
 }
 
 #touchControls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 400px;
+  margin: 0 auto 20px;
+}
+
+#moveControls {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
   gap: 10px;
-  max-width: 200px;
-  margin: 0 auto 20px;
 }
 
 #touchControls button {
-  width: 60px;
-  height: 60px;
-  font-size: 1.5em;
+  width: 72px;
+  height: 72px;
+  font-size: 1.8em;
   font-weight: bold;
   border: none;
   border-radius: 10px;
@@ -91,10 +97,8 @@ body {
 #leftBtn { grid-column: 1; grid-row: 2; }
 #rightBtn { grid-column: 3; grid-row: 2; }
 #upBtn { grid-column: 2; grid-row: 1; }
-#downBtn { grid-column: 2; grid-row: 2; }
-#shootBtn { 
-  grid-column: 2; 
-  grid-row: 3; 
+#downBtn { grid-column: 2; grid-row: 3; }
+#shootBtn {
   background: linear-gradient(145deg, #f44336, #d32f2f);
 }
 
@@ -165,11 +169,11 @@ body {
       width: 100%;
       max-width: 350px;
   }
-  
+
   #touchControls button {
-      width: 50px;
-      height: 50px;
-      font-size: 1.2em;
+      width: 60px;
+      height: 60px;
+      font-size: 1.44em;
   }
   
   #instructions {
@@ -183,8 +187,8 @@ body {
   }
   
   #touchControls button {
-      width: 40px;
-      height: 40px;
-      font-size: 1em;
+      width: 48px;
+      height: 48px;
+      font-size: 1.2em;
   }
 }


### PR DESCRIPTION
## Summary
- Rework touch controls so movement buttons sit on the left and the shoot button sits on the right.
- Enlarge all touch buttons by 20% and update responsive sizes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d3cb8ea5483309a51971a9cc48647