### PR TITLE
Add stage system with timed boss fights

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
             <span id="score">スコア: 0</span>
             <span id="life">ライフ: ❤️❤️❤️</span>
             <span id="power">パワー: 1</span>
+            <span id="stage">ステージ: 1</span>
         </div>
         <canvas id="gameCanvas" width="400" height="600"></canvas>
         <div id="gameControls">


### PR DESCRIPTION
## Summary
- add stage display and track stage state
- spawn a boss after two minutes and reset stage when defeated
- advance stage counter upon boss defeat for continuous progression

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d7e8a7e4c8330a9485bbefb372dcd