### PR TITLE
fix: keep game info visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,9 +12,10 @@ body {
   color: white;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   min-height: 100vh;
   padding: 10px;
+  overflow-y: auto;
 }
 
 #gameContainer {


### PR DESCRIPTION
## Summary
- anchor layout to top so life, score, and other game info stay visible
- allow vertical scrolling when content exceeds screen height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e10f521848330bc8811163cd00d55