### PR TITLE
Add boss countdown and detailed SVG boss

### DIFF
--- a/boss.svg
+++ b/boss.svg
@@ -1,7 +1,17 @@
-<svg width="200" height="150" viewBox="0 0 200 150" xmlns="http://www.w3.org/2000/svg">
-  <rect x="0" y="50" width="200" height="50" fill="#8B0000"/>
-  <circle cx="50" cy="75" r="20" fill="#FFD700"/>
-  <circle cx="150" cy="75" r="20" fill="#FFD700"/>
-  <polygon points="100,0 120,50 80,50" fill="#FF6347"/>
-  <polygon points="100,150 120,100 80,100" fill="#FF6347"/>
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="body" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8B0000"/>
+      <stop offset="100%" stop-color="#550000"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="60" width="160" height="80" fill="url(#body)" stroke="#FFD700" stroke-width="3"/>
+  <circle cx="60" cy="100" r="20" fill="#FFD700"/>
+  <circle cx="140" cy="100" r="20" fill="#FFD700"/>
+  <rect x="85" y="20" width="30" height="40" fill="#FF6347"/>
+  <rect x="85" y="140" width="30" height="40" fill="#FF6347"/>
+  <polygon points="20,100 0,80 0,120" fill="#AA0000"/>
+  <polygon points="180,100 200,80 200,120" fill="#AA0000"/>
+  <circle cx="100" cy="100" r="10" fill="#ffffff"/>
+  <circle cx="100" cy="100" r="5" fill="#000000"/>
 </svg>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,10 @@ const restartBtn = document.getElementById('restartBtn');
 
 const STAGE_DURATION = 120 * 60; // 2 minutes at 60 FPS
 
+// ボス画像の読み込み
+const bossImg = new Image();
+bossImg.src = 'boss.svg';
+
 // ゲーム状態
 let gameState = {
     playing: true,
@@ -178,8 +182,8 @@ class Enemy {
     constructor(x, y, type = 'normal') {
         this.x = x;
         this.y = y;
-        this.width = 25;
-        this.height = 25;
+        this.width = type === 'boss' ? 75 : 25;
+        this.height = type === 'boss' ? 75 : 25;
         this.speed = 2;
         this.type = type;
         this.hp = type === 'boss' ? 10 : 1;
@@ -209,19 +213,22 @@ class Enemy {
     draw() {
         if (this.type === 'boss') {
             // ボス敵
-            ctx.fillStyle = '#ff0066';
-            ctx.fillRect(this.x - this.width/2, this.y - this.height/2, this.width, this.height);
-            
+            ctx.drawImage(bossImg, this.x - this.width / 2, this.y - this.height / 2, this.width, this.height);
+
             // HPバー
             ctx.fillStyle = '#ff0000';
-            ctx.fillRect(this.x - this.width/2, this.y - this.height/2 - 10, this.width, 4);
+            ctx.fillRect(this.x - this.width / 2, this.y - this.height / 2 - 10, this.width, 4);
             ctx.fillStyle = '#00ff00';
-            ctx.fillRect(this.x - this.width/2, this.y - this.height/2 - 10, 
-                        this.width * (this.hp / this.maxHp), 4);
+            ctx.fillRect(
+                this.x - this.width / 2,
+                this.y - this.height / 2 - 10,
+                this.width * (this.hp / this.maxHp),
+                4
+            );
         } else {
             // 通常敵
             ctx.fillStyle = '#ff6666';
-            ctx.fillRect(this.x - this.width/2, this.y - this.height/2, this.width, this.height);
+            ctx.fillRect(this.x - this.width / 2, this.y - this.height / 2, this.width, this.height);
         }
     }
 }
@@ -554,6 +561,17 @@ function draw() {
 
     // 爆発描画
     explosions.forEach(explosion => explosion.draw());
+
+    // ボス登場までのカウントダウン表示
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '16px Arial';
+    ctx.textAlign = 'left';
+    if (!gameState.bossActive) {
+        const remaining = Math.max(0, Math.ceil((STAGE_DURATION - gameState.stageFrame) / 60));
+        ctx.fillText(`ボス登場まで: ${remaining}秒`, 10, 20);
+    } else {
+        ctx.fillText('ボス登場！', 10, 20);
+    }
 }
 
 // メインゲームループ


### PR DESCRIPTION
## Summary
- Show countdown to boss appearance and message when boss arrives
- Enlarge boss to 300% of normal enemies and draw using a detailed SVG sprite

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3a5029083309cecdab80ebbe676