### PR TITLE
Make boss appear after 60 seconds

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ const gameOverElement = document.getElementById('gameOver');
 const finalScoreElement = document.getElementById('finalScore');
 const restartBtn = document.getElementById('restartBtn');
 
-const STAGE_DURATION = 120 * 60; // 2 minutes at 60 FPS
+const STAGE_DURATION = 60 * 60; // 1 minute at 60 FPS
 
 // ボス画像の読み込み
 const bossImg = new Image();


### PR DESCRIPTION
## Summary
- Make the boss spawn after 60 seconds by adjusting the stage duration constant.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eeabf7eec8330935ac10408daa70f