### PR TITLE
feat: initialize background music on user input

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,6 +24,18 @@ const bossBgm = new Audio('audio/Assault_of_enemy.mp3');
 bgm.loop = true;
 bossBgm.loop = true;
 
+// ユーザー操作後にBGMを開始
+let audioInitialized = false;
+function initAudio() {
+    if (!audioInitialized) {
+        bgm.play().catch(() => {});
+        audioInitialized = true;
+    }
+}
+document.addEventListener('keydown', initAudio, { once: true });
+document.addEventListener('touchstart', initAudio, { once: true });
+document.addEventListener('mousedown', initAudio, { once: true });
+
 // ゲーム状態
 let gameState = {
     playing: true,


### PR DESCRIPTION
## Summary
- start stage background music after first user interaction
- ensure audio files loop and are ready for boss transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68904605a08c8330bc6923acdc78983a