### PR TITLE
Scale game for mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>ビームシューターゲーム</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const lifeElement = document.getElementById('life');
 const powerElement = document.getElementById('power');
 const shieldElement = document.getElementById('shield');
 const stageElement = document.getElementById('stage');
+const gameContainer = document.getElementById('gameContainer');
 const gameOverElement = document.getElementById('gameOver');
 const finalScoreElement = document.getElementById('finalScore');
 const restartBtn = document.getElementById('restartBtn');
@@ -738,3 +739,19 @@ function gameLoop() {
 // ゲーム開始
 gameLoop();
 bgm.play().catch(() => {});
+
+// 画面サイズに合わせてゲーム全体をスケーリング
+function resizeGame() {
+    gameContainer.style.transform = 'none';
+    const rect = gameContainer.getBoundingClientRect();
+    const scale = Math.min(
+        window.innerWidth / rect.width,
+        window.innerHeight / rect.height,
+        1
+    );
+    gameContainer.style.transform = `scale(${scale})`;
+}
+
+window.addEventListener('resize', resizeGame);
+window.addEventListener('orientationchange', resizeGame);
+resizeGame();

--- a/style.css
+++ b/style.css
@@ -12,16 +12,17 @@ body {
   color: white;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   min-height: 100vh;
   padding: 10px;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 #gameContainer {
   text-align: center;
   max-width: 500px;
   width: 100%;
+  transform-origin: top center;
 }
 
 #gameTitle {


### PR DESCRIPTION
## Summary
- Prevent mobile zoom and scrolling by locking viewport settings
- Center game container and hide page overflow for a fixed screen fit
- Add dynamic scaling logic so the entire interface fits in mobile viewports

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890673b9100833087517c4817d279a0