### PR TITLE
fix: prevent screen scrolling on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,6 +37,11 @@ document.addEventListener('keydown', initAudio, { once: true });
 document.addEventListener('touchstart', initAudio, { once: true });
 document.addEventListener('mousedown', initAudio, { once: true });
 
+// モバイル操作時の画面スクロールやズームを防止
+document.addEventListener('touchmove', (e) => {
+    e.preventDefault();
+}, { passive: false });
+
 // ゲーム状態
 let gameState = {
     playing: true,

--- a/style.css
+++ b/style.css
@@ -16,6 +16,8 @@ body {
   min-height: 100vh;
   padding: 10px;
   overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: contain;
 }
 
 #gameContainer {


### PR DESCRIPTION
## Summary
- stop touch gestures from scrolling or zooming the game
- block browser default touchmove behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907f0884ac8330b143b953fe085430