### PR TITLE
Ensure boss is not filtered before entering screen

### DIFF
--- a/script.js
+++ b/script.js
@@ -898,7 +898,7 @@ function gameLoop() {
 
         // 敵更新
         enemies.forEach(enemy => enemy.update());
-        enemies = enemies.filter(enemy => enemy.y < canvas.height + 50 && enemy.y > -50);
+        enemies = enemies.filter(enemy => enemy.y < canvas.height + 50 && (enemy.y > -50 || enemy.type === 'boss'));
 
         // アイテム更新
         items.forEach(item => item.update());


### PR DESCRIPTION
## Summary
- prevent boss from being removed while off-screen so it can enter after the warning

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891793b71a48330b27e48424f35aa6a