### PR TITLE
Increase boss health per stage

### DIFF
--- a/script.js
+++ b/script.js
@@ -258,8 +258,7 @@ class Enemy {
             this.width = 270;
             this.height = 270;
             const stage = gameState.stage;
-            const hpTable = {1: 8, 2: 12, 3: 15};
-            this.hp = hpTable[stage] || (8 + (stage - 1) * 3 + (stage > 1 ? 1 : 0));
+            this.hp = 10 * (stage + 1); // Stage 1:20, Stage 2:30, Stage 3:40...
             this.maxHp = this.hp;
             this.speed = 1 + stage * 0.5;
             this.bulletSpeed = 3 + stage;


### PR DESCRIPTION
## Summary
- scale boss HP to start at 20 and increase by 10 each stage, making early bosses less fragile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f57311c083309dbcfd1104be70ab