### PR TITLE
Increase boss hit points

### DIFF
--- a/script.js
+++ b/script.js
@@ -259,7 +259,7 @@ class Enemy {
             this.width = 270;
             this.height = 270;
             const stage = gameState.stage;
-            this.hp = 10 * (stage + 1); // Stage 1:20, Stage 2:30, Stage 3:40...
+            this.hp = 50; // Requires 50 hits to defeat
             this.maxHp = this.hp;
             this.speed = 1 + stage * 0.5;
             this.bulletSpeed = 3 + stage;


### PR DESCRIPTION
## Summary
- Require 50 hits to defeat the boss by setting its HP to 50

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ecdc293c83308f6f855c3c433c78