### PR TITLE
Ensure boss battle music plays

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,6 +41,12 @@ let audioInitialized = false;
 function initAudio() {
     if (!audioInitialized) {
         bgm.play().catch(() => {});
+        bossBgm.play()
+            .then(() => {
+                bossBgm.pause();
+                bossBgm.currentTime = 0;
+            })
+            .catch(() => {});
         audioInitialized = true;
     }
 }


### PR DESCRIPTION
## Summary
- Initialize boss battle music during first user interaction so it can start when the boss appears

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6897379316788330a7c3fef785f37d8b