### PR TITLE
Adjust controller buttons to 110% size

### DIFF
--- a/style.css
+++ b/style.css
@@ -75,9 +75,9 @@ body {
 }
 
 #touchControls button {
-  width: calc(72px * 1.3 * 1.1);
-  height: calc(72px * 1.3 * 1.1);
-  font-size: calc(1.8em * 1.3 * 1.1);
+  width: calc(72px * 1.1);
+  height: calc(72px * 1.1);
+  font-size: calc(1.8em * 1.1);
   font-weight: bold;
   border: none;
   border-radius: 10px;
@@ -104,9 +104,9 @@ body {
 #downBtn { grid-column: 2; grid-row: 3; }
 #shootBtn {
   background: linear-gradient(145deg, #f44336, #d32f2f);
-  width: calc(72px * 1.5 * 1.3 * 1.1);
-  height: calc(72px * 1.5 * 1.3 * 1.1);
-  font-size: calc(1.8em * 1.5 * 1.3 * 1.1);
+  width: calc(72px * 1.5 * 1.1);
+  height: calc(72px * 1.5 * 1.1);
+  font-size: calc(1.8em * 1.5 * 1.1);
 }
 
 
@@ -166,17 +166,17 @@ body {
       max-width: 350px;
   }
 
-  #touchControls button {
-      width: calc(60px * 1.3 * 1.1);
-      height: calc(60px * 1.3 * 1.1);
-      font-size: calc(1.44em * 1.3 * 1.1);
-  }
+    #touchControls button {
+        width: calc(60px * 1.1);
+        height: calc(60px * 1.1);
+        font-size: calc(1.44em * 1.1);
+    }
 
-  #shootBtn {
-      width: calc(60px * 1.5 * 1.3 * 1.1);
-      height: calc(60px * 1.5 * 1.3 * 1.1);
-      font-size: calc(1.44em * 1.5 * 1.3 * 1.1);
-  }
+    #shootBtn {
+        width: calc(60px * 1.5 * 1.1);
+        height: calc(60px * 1.5 * 1.1);
+        font-size: calc(1.44em * 1.5 * 1.1);
+    }
   
 }
 
@@ -186,14 +186,14 @@ body {
   }
   
   #touchControls button {
-      width: calc(48px * 1.3 * 1.1);
-      height: calc(48px * 1.3 * 1.1);
-      font-size: calc(1.2em * 1.3 * 1.1);
+      width: calc(48px * 1.1);
+      height: calc(48px * 1.1);
+      font-size: calc(1.2em * 1.1);
   }
 
   #shootBtn {
-      width: calc(48px * 1.5 * 1.3 * 1.1);
-      height: calc(48px * 1.5 * 1.3 * 1.1);
-      font-size: calc(1.2em * 1.5 * 1.3 * 1.1);
+      width: calc(48px * 1.5 * 1.1);
+      height: calc(48px * 1.5 * 1.1);
+      font-size: calc(1.2em * 1.5 * 1.1);
   }
 }


### PR DESCRIPTION
## Summary
- Scale touch controller buttons to 110% and resize shoot button accordingly
- Update responsive breakpoints to apply the same 110% scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e61093588330962a79af2289ad85