### PR TITLE
Add stage clear screen and new boss/item mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,11 @@
             <p>最終スコア: <span id="finalScore">0</span></p>
             <button id="restartBtn">もう一度プレイ</button>
         </div>
+        <div id="gameClear" class="hidden">
+            <h2>ゲームクリア</h2>
+            <p>最終スコア: <span id="clearScore">0</span></p>
+            <button id="clearRestartBtn">もう一度プレイ</button>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -110,7 +110,7 @@ body {
 }
 
 
-#gameOver {
+#gameOver, #gameClear {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -128,7 +128,13 @@ body {
   font-size: 2em;
 }
 
-#restartBtn {
+#gameClear h2 {
+  color: #4CAF50;
+  margin-bottom: 15px;
+  font-size: 2em;
+}
+
+#restartBtn, #clearRestartBtn {
   background: linear-gradient(145deg, #4CAF50, #45a049);
   color: white;
   border: none;
@@ -140,7 +146,7 @@ body {
   transition: all 0.3s;
 }
 
-#restartBtn:hover {
+#restartBtn:hover, #clearRestartBtn:hover {
   transform: scale(1.05);
   box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
 }


### PR DESCRIPTION
## Summary
- Show a game clear screen after defeating the stage 5 boss
- Extend boss attack patterns with homing missiles and radial bullet barrages
- Introduce aqua rapid-fire and dark purple sleep-missile support items

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/31-shoot/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6899898668708330b640db2d7a5f21e6