### PR TITLE
Add start screen and item descriptions, buff boss HP

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,25 @@
                 <button id="shootBtn">🔫</button>
             </div>
         </div>
+        <div id="startScreen">
+            <h2>アイテム説明</h2>
+            <ul id="itemList">
+                <li><span class="colorBox" style="background:red;"></span>ショットレベルアップ</li>
+                <li><span class="colorBox" style="background:orange;"></span>ワイドショット</li>
+                <li><span class="colorBox" style="background:purple;"></span>ホーミングショット</li>
+                <li><span class="colorBox" style="background:green;"></span>ライフ回復</li>
+                <li><span class="colorBox" style="background:blue;"></span>バリア追加</li>
+                <li><span class="colorBox" style="background:black;"></span>ボム追加</li>
+                <li><span class="colorBox" style="background:silver;"></span>サテライト追加</li>
+                <li><span class="colorBox" style="background:deepskyblue;"></span>連射速度アップ</li>
+                <li><span class="colorBox" style="background:magenta;"></span>貫通弾</li>
+                <li><span class="colorBox" style="background:pink;"></span>アイテム吸引</li>
+                <li><span class="colorBox" style="background:darkviolet;"></span>スリープミサイル</li>
+                <li><span class="colorBox" style="background:aqua;"></span>移動速度アップ</li>
+                <li><span class="colorBox" style="background:lavenderblush; border:1px solid #000;"></span>敵スロー</li>
+            </ul>
+            <button id="startBtn">ゲームスタート</button>
+        </div>
         <div id="gameOver" class="hidden">
             <h2>ゲームオーバー</h2>
             <p>最終スコア: <span id="finalScore">0</span></p>

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ const restartBtn = document.getElementById('restartBtn');
 const gameClearElement = document.getElementById('gameClear');
 const clearScoreElement = document.getElementById('clearScore');
 const clearRestartBtn = document.getElementById('clearRestartBtn');
+const startScreen = document.getElementById('startScreen');
+const startBtn = document.getElementById('startBtn');
 
 const STAGE_DURATION = 60 * 60; // 1 minute at 60 FPS
 
@@ -24,7 +26,7 @@ function getBossConfig(stage) {
     const attackPattern = (stage - 1) % 5;
     const colors = ['#ff0000', '#00ff00', '#0000ff', '#ff00ff', '#00ffff', '#ffff00', '#ffffff', '#ffa500', '#ff1493'];
     const color = colors[(stage - 1) % colors.length];
-    const hp = stage + 1;
+    const hp = (stage + 1) * 100;
     return { pattern, attackPattern, color, hp };
 }
 
@@ -53,9 +55,6 @@ function initAudio() {
         audioInitialized = true;
     }
 }
-document.addEventListener('keydown', initAudio, { once: true });
-document.addEventListener('touchstart', initAudio, { once: true });
-document.addEventListener('mousedown', initAudio, { once: true });
 
 // モバイル操作時の画面スクロールやズームを防止
 document.addEventListener('touchmove', (e) => {
@@ -64,7 +63,7 @@ document.addEventListener('touchmove', (e) => {
 
 // ゲーム状態
 let gameState = {
-    playing: true,
+    playing: false,
     score: 0,
     life: 3,
     power: 1,
@@ -200,6 +199,7 @@ document.getElementById('shootBtn').addEventListener('mouseup', (e) => {
 // リスタートボタン
 restartBtn.addEventListener('click', restartGame);
 clearRestartBtn.addEventListener('click', restartGame);
+startBtn.addEventListener('click', startGame);
 
 // 弾丸クラス
 class Bullet {
@@ -841,8 +841,16 @@ function gameClear() {
     bossBgm.pause();
 }
 
+function startGame() {
+    startScreen.classList.add('hidden');
+    gameState.playing = true;
+    initAudio();
+    bgm.play().catch(() => {});
+}
+
 // ゲーム再開
 function restartGame() {
+    startScreen.classList.add('hidden');
     gameState = {
         playing: true,
         score: 0,

--- a/style.css
+++ b/style.css
@@ -134,7 +134,7 @@ body {
   font-size: 2em;
 }
 
-#restartBtn, #clearRestartBtn {
+#restartBtn, #clearRestartBtn, #startBtn {
   background: linear-gradient(145deg, #4CAF50, #45a049);
   color: white;
   border: none;
@@ -146,13 +146,52 @@ body {
   transition: all 0.3s;
 }
 
-#restartBtn:hover, #clearRestartBtn:hover {
+#restartBtn:hover, #clearRestartBtn:hover, #startBtn:hover {
   transform: scale(1.05);
   box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
 }
 
 .hidden {
   display: none;
+}
+
+#startScreen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.9);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#itemList {
+  text-align: left;
+  margin-bottom: 15px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+#itemList li {
+  list-style: none;
+  margin: 4px 0;
+  display: flex;
+  align-items: center;
+  font-size: 0.9em;
+}
+
+.colorBox {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-right: 8px;
+  border: 1px solid #fff;
 }
 
 /* スマホ対応 */


### PR DESCRIPTION
## Summary
- Add start overlay with game start button and item descriptions
- Start game on button click and pause updates until then
- Increase boss HP values for tougher battles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f36230a4833097370108d9af87fe