### PR TITLE
Hide start screen when game begins

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,6 +171,10 @@ body {
   box-sizing: border-box;
 }
 
+#startScreen.hidden {
+  display: none;
+}
+
 #itemList {
   text-align: left;
   margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- Ensure start screen disappears once gameplay starts by overriding its flex display when the `hidden` class is applied.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f55620248330889eb5c6b1e8ba3e