### PR TITLE
Hide start screen when game begins and clarify item abilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,19 +31,19 @@
         <div id="startScreen">
             <h2>アイテム説明</h2>
             <ul id="itemList">
-                <li><span class="colorBox" style="background:red;"></span>ショットレベルアップ</li>
-                <li><span class="colorBox" style="background:orange;"></span>ワイドショット</li>
-                <li><span class="colorBox" style="background:purple;"></span>ホーミングショット</li>
-                <li><span class="colorBox" style="background:green;"></span>ライフ回復</li>
-                <li><span class="colorBox" style="background:blue;"></span>バリア追加</li>
-                <li><span class="colorBox" style="background:black;"></span>ボム追加</li>
-                <li><span class="colorBox" style="background:silver;"></span>サテライト追加</li>
-                <li><span class="colorBox" style="background:deepskyblue;"></span>連射速度アップ</li>
-                <li><span class="colorBox" style="background:magenta;"></span>貫通弾</li>
-                <li><span class="colorBox" style="background:pink;"></span>アイテム吸引</li>
-                <li><span class="colorBox" style="background:darkviolet;"></span>スリープミサイル</li>
-                <li><span class="colorBox" style="background:aqua;"></span>移動速度アップ</li>
-                <li><span class="colorBox" style="background:lavenderblush; border:1px solid #000;"></span>敵スロー</li>
+                <li><span class="colorBox" style="background:red;"></span>ショットレベルアップ: ショットが強化される</li>
+                <li><span class="colorBox" style="background:orange;"></span>ワイドショット: 弾が横に広がる</li>
+                <li><span class="colorBox" style="background:purple;"></span>ホーミングショット: 弾が敵を追尾する</li>
+                <li><span class="colorBox" style="background:green;"></span>ライフ回復: ライフを回復する</li>
+                <li><span class="colorBox" style="background:blue;"></span>バリア追加: 一度だけ攻撃を防ぐ</li>
+                <li><span class="colorBox" style="background:black;"></span>ボム追加: ボムストックが増える</li>
+                <li><span class="colorBox" style="background:silver;"></span>サテライト追加: サポート機が追加される</li>
+                <li><span class="colorBox" style="background:deepskyblue;"></span>連射速度アップ: 射撃間隔が短くなる</li>
+                <li><span class="colorBox" style="background:magenta;"></span>貫通弾: 弾が敵を貫通する</li>
+                <li><span class="colorBox" style="background:pink;"></span>アイテム吸引: 周囲のアイテムを引き寄せる</li>
+                <li><span class="colorBox" style="background:darkviolet;"></span>スリープミサイル: 敵を一時的に停止させる</li>
+                <li><span class="colorBox" style="background:aqua;"></span>移動速度アップ: 移動速度が上がる</li>
+                <li><span class="colorBox" style="background:lavenderblush; border:1px solid #000;"></span>敵スロー: 敵の動きが遅くなる</li>
             </ul>
             <button id="startBtn">ゲームスタート</button>
         </div>

--- a/style.css
+++ b/style.css
@@ -171,6 +171,10 @@ body {
   box-sizing: border-box;
 }
 
+#startScreen.hidden {
+  display: none;
+}
+
 #itemList {
   text-align: left;
   margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- Ensure start screen disappears once gameplay starts by overriding its flex display when the `hidden` class is applied
- List what ability each item grants on the start screen

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f55620248330889eb5c6b1e8ba3e