### PR TITLE
Slow stage 4 boss homing bullets

### DIFF
--- a/script.js
+++ b/script.js
@@ -295,6 +295,10 @@ class Enemy {
             this.maxHp = this.hp;
             this.speed = 1 + stage * 0.5;
             this.bulletSpeed = 3 + stage;
+            if (stage === 4) {
+                // ステージ4のボスの追尾弾を少し遅くする
+                this.bulletSpeed = 5;
+            }
             this.shootInterval = Math.max(20, 60 - stage * 5);
             this.shootCooldown = this.shootInterval;
             this.pattern = config.pattern;


### PR DESCRIPTION
## Summary
- Slow down stage 4 boss' homing shots for a fairer challenge.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b788f74883308ee4277db7f52eaf