### PR TITLE
Add satellite contact damage to enemies

### DIFF
--- a/script.js
+++ b/script.js
@@ -822,6 +822,30 @@ function checkCollisions() {
         }
     });
 
+    // サテライトと敵の当たり判定（接触ダメージ）
+    satellites.forEach(sat => {
+        enemies.forEach((enemy, enemyIndex) => {
+            const dist = Math.hypot(sat.x - enemy.x, sat.y - enemy.y);
+            const enemyRadius = Math.max(enemy.width, enemy.height) / 2;
+            if (dist < enemyRadius + 8) {
+                enemy.hp--;
+                if (enemy.hp <= 0) {
+                    explosions.push(new Explosion(enemy.x, enemy.y));
+                    gameState.score += enemy.type === 'boss' ? 100 : 10;
+
+                    if (Math.random() < 0.3) {
+                        spawnPowerUp(enemy.x, enemy.y);
+                    }
+
+                    enemies.splice(enemyIndex, 1);
+                    if (enemy.type === 'boss') {
+                        nextStage();
+                    }
+                }
+            }
+        });
+    });
+
 }
 
 function useBomb() {


### PR DESCRIPTION
## Summary
- fix stage progression when bosses are defeated by satellites
- allow satellites to deal minor contact damage to enemies

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5177789848330936557fd45719df0