### PR TITLE
Add bomb stock button and screen-clear mechanic

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
                     <button id="downBtn">↓</button>
                 </div>
                 <button id="shootBtn">🔫</button>
+                <div id="bombContainer" class="hidden">
+                    <button id="bombBtn">💣</button>
+                    <div id="bombCountDisplay">0</div>
+                </div>
             </div>
         </div>
         <div id="startScreen">

--- a/script.js
+++ b/script.js
@@ -17,6 +17,9 @@ const clearScoreElement = document.getElementById('clearScore');
 const clearRestartBtn = document.getElementById('clearRestartBtn');
 const startScreen = document.getElementById('startScreen');
 const startBtn = document.getElementById('startBtn');
+const bombContainer = document.getElementById('bombContainer');
+const bombCountDisplay = document.getElementById('bombCountDisplay');
+const bombBtn = document.getElementById('bombBtn');
 
 const STAGE_DURATION = 60 * 60; // 1 minute at 60 FPS
 const MAX_SATELLITES = 4; // Maximum number of support satellites
@@ -175,6 +178,11 @@ document.getElementById('shootBtn').addEventListener('touchend', (e) => {
     touchButtons.shoot = false;
 }, { passive: false });
 
+bombBtn.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    useBomb();
+}, { passive: false });
+
 // マウスボタンの設定
 document.getElementById('leftBtn').addEventListener('mousedown', () => touchButtons.left = true);
 document.getElementById('leftBtn').addEventListener('mouseup', () => touchButtons.left = false);
@@ -195,6 +203,11 @@ document.getElementById('shootBtn').addEventListener('mousedown', (e) => {
 document.getElementById('shootBtn').addEventListener('mouseup', (e) => {
     e.preventDefault();
     touchButtons.shoot = false;
+});
+
+bombBtn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    useBomb();
 });
 
 // リスタートボタン
@@ -830,6 +843,7 @@ function useBomb() {
         enemies.forEach(enemy => explosions.push(new Explosion(enemy.x, enemy.y)));
         enemies = [];
         bullets = bullets.filter(b => b.dy < 0);
+        updateUI();
     }
 }
 
@@ -930,6 +944,12 @@ function updateUI() {
     powerElement.textContent = `パワー: ${gameState.power}${gameState.power >= 3 ? ' (MAX)' : ''}`;
     shieldElement.textContent = `バリア: ${player.shield}`;
     stageElement.textContent = `ステージ: ${gameState.stage}`;
+    if (player.bombCount > 0) {
+        bombContainer.classList.remove('hidden');
+        bombCountDisplay.textContent = player.bombCount;
+    } else {
+        bombContainer.classList.add('hidden');
+    }
 }
 
 // 描画

--- a/style.css
+++ b/style.css
@@ -102,12 +102,27 @@ body {
 #rightBtn { grid-column: 3; grid-row: 2; }
 #upBtn { grid-column: 2; grid-row: 1; }
 #downBtn { grid-column: 2; grid-row: 3; }
-#shootBtn {
-  background: linear-gradient(145deg, #f44336, #d32f2f);
-  width: calc(72px * 1.5 * 1.5 * 1.1);
-  height: calc(72px * 1.5 * 1.5 * 1.1);
-  font-size: calc(1.8em * 1.5 * 1.5 * 1.1);
-}
+  #shootBtn {
+    background: linear-gradient(145deg, #f44336, #d32f2f);
+    width: calc(72px * 1.5 * 1.5 * 1.1);
+    height: calc(72px * 1.5 * 1.5 * 1.1);
+    font-size: calc(1.8em * 1.5 * 1.5 * 1.1);
+  }
+
+  #bombContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  #bombBtn {
+    background: linear-gradient(145deg, #9e9e9e, #757575);
+  }
+
+  #bombCountDisplay {
+    margin-top: 5px;
+    font-size: 1.2em;
+  }
 
 
 #gameOver, #gameClear {


### PR DESCRIPTION
## Summary
- Add bomb button with stock counter to touch controls
- Track bomb count and hide button when depleted
- Trigger bomb to clear enemies and remove enemy bullets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5199220348330bbb850937d1ea6e8