### PR TITLE
Fix boss kill via bomb not progressing

### DIFF
--- a/script.js
+++ b/script.js
@@ -865,9 +865,18 @@ function checkCollisions() {
 function useBomb() {
     if (player.bombCount > 0) {
         player.bombCount--;
-        enemies.forEach(enemy => explosions.push(new Explosion(enemy.x, enemy.y)));
+        let bossDefeated = false;
+        enemies.forEach(enemy => {
+            explosions.push(new Explosion(enemy.x, enemy.y));
+            if (enemy.type === 'boss') {
+                bossDefeated = true;
+            }
+        });
         enemies = [];
         bullets = bullets.filter(b => b.dy < 0);
+        if (bossDefeated) {
+            nextStage();
+        }
         updateUI();
     }
 }


### PR DESCRIPTION
## Summary
- ensure bomb defeat of boss triggers stage transition

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c65909c9308330ab655cd172a059ce