### PR TITLE
Boost stage 6 climax

### DIFF
--- a/boss_final.svg
+++ b/boss_final.svg
@@ -1,0 +1,19 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="body" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4b0000"/>
+      <stop offset="100%" stop-color="#110000"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="50" width="180" height="100" fill="url(#body)" stroke="#ff0000" stroke-width="4"/>
+  <polygon points="10,50 0,30 20,30" fill="#ff0000"/>
+  <polygon points="190,50 180,30 200,30" fill="#ff0000"/>
+  <polygon points="10,150 0,170 20,170" fill="#ff0000"/>
+  <polygon points="190,150 180,170 200,170" fill="#ff0000"/>
+  <circle cx="60" cy="100" r="25" fill="#ffcc00"/>
+  <circle cx="140" cy="100" r="25" fill="#ffcc00"/>
+  <rect x="85" y="10" width="30" height="40" fill="#990000"/>
+  <rect x="85" y="150" width="30" height="40" fill="#990000"/>
+  <circle cx="100" cy="100" r="12" fill="#ffffff"/>
+  <circle cx="100" cy="100" r="6" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary
- Intensify final boss with stronger attacks, bigger sprite, and dedicated image
- Play boss battle music from the start of stage 6 for a last-boss atmosphere
- Toughen up regular enemies and overall boss firepower

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c74615ecc48330adcfdcd5f3cf0f35