### PR TITLE
Prevent bomb from instantly defeating boss

### DIFF
--- a/script.js
+++ b/script.js
@@ -865,16 +865,28 @@ function checkCollisions() {
 function useBomb() {
     if (player.bombCount > 0) {
         player.bombCount--;
-        let bossDefeated = false;
-        enemies.forEach(enemy => {
+        let bossKilled = false;
+        enemies = enemies.filter(enemy => {
             explosions.push(new Explosion(enemy.x, enemy.y));
             if (enemy.type === 'boss') {
-                bossDefeated = true;
+                // ボムはボスを即死させず、一定ダメージを与える
+                enemy.hp -= Math.floor(enemy.maxHp * 0.25);
+                if (enemy.hp <= 0) {
+                    bossKilled = true;
+                    gameState.score += 100;
+                    return false;
+                }
+                return true;
+            } else {
+                gameState.score += 10;
+                if (Math.random() < 0.3) {
+                    spawnPowerUp(enemy.x, enemy.y);
+                }
+                return false;
             }
         });
-        enemies = [];
         bullets = bullets.filter(b => b.dy < 0);
-        if (bossDefeated) {
+        if (bossKilled) {
             nextStage();
         }
         updateUI();


### PR DESCRIPTION
## Summary
- Prevent bomb from instantly killing boss by inflicting partial damage
- Properly transition to next stage when bomb finishes the boss
- Award points and drop power-ups for enemies destroyed by bomb

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6827d3e4883308d72c4d381da8232